### PR TITLE
feat(build): multi-arch nix setup and JDK 17

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,20 +1,58 @@
 {
   "nodes": {
-    "nixpkgs": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-v2NB8B3EahTvJ0Zg6QVJVUjq2cBwZ0UKTwMr2nv9718=",
-        "path": "/nix/store/hpyq11kyx19ggxi78ryhhhc9ai9p7jxp-source",
-        "type": "path"
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1758346548,
+        "narHash": "sha256-afXE7AJ7MY6wY1pg/Y6UPHNYPy5GtUKeBkrZZ/gC71E=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b2a3852bd078e68dd2b3dfa8c00c67af1f0a7d20",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,19 +1,23 @@
 {
-  description = "LCAAC flake";
-  outputs = inputs@{ nixpkgs, ...}:
-  {
-    devShells = {
-      aarch64-darwin.default =
-      let
-        pkgs = nixpkgs.legacyPackages.aarch64-darwin;
-      in
-      pkgs.mkShell {
-        name = "lcaac-dev-shell";
-    	packages = with pkgs; [
-    	  jdk23
-    	  gradle
-    	];
-      };
-    };
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+    flake-utils.url = "github:numtide/flake-utils";
   };
+  description = "LCAAC flake";
+  outputs = inputs@{ nixpkgs, flake-utils, ...}:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          name = "lcaac-dev-shell";
+          packages = with pkgs; [
+            jdk17
+            gradle
+          ];
+        };
+      }
+    );
 }


### PR DESCRIPTION
**Context**

The current Nix setup is Darwin-only, and the JDK specified is `jdk23`, but `gradle.properties` specifies version 17.

This meant it didn't build on my Ubuntu system.

**Changes**

- Make Nix config architecture agnostic
- Change JDK version to 17
- Pin Nix version in `flake.nix`